### PR TITLE
sort report by date

### DIFF
--- a/expense_report.py
+++ b/expense_report.py
@@ -2,11 +2,12 @@ class ExpenseReport:
     def __init__(self):
         self.expense_list = []
         self.beginningBalance = 0
-
     def generate_report(self):
         report_so_far = "| Date | Description | Amount | Balance |"
         currentBalance = self.beginningBalance
-        for expense in self.expense_list:
+        sorted_date_expenses = sorted(self.expense_list, key=lambda item: item.date)
+        # https://chatgpt.com/share/6724dbe7-b0a0-8011-aca5-60658b1320d5
+        for expense in sorted_date_expenses:
             currentBalance = currentBalance - expense.amount
             expenseLine = self.createExpenseLine(expense, currentBalance)
             report_so_far = report_so_far + expenseLine

--- a/test_expense_report.py
+++ b/test_expense_report.py
@@ -4,7 +4,7 @@ from assertpy import assert_that
 
 from expense_report import ExpenseReport
 
-from custom_string_assert import is_equal_to_with_diff
+import custom_string_assert
 
 class ExpenseReportTests(unittest.TestCase):
     def test_should_output_date_description_amount_balance_when_the_expense_report_has_no_expenses(self):

--- a/test_expense_report.py
+++ b/test_expense_report.py
@@ -149,6 +149,34 @@ class ExpenseReportTests(unittest.TestCase):
 | 10/03/2024 | Car Repair | 450.00 | 451.00 |"""))
 
 
+    def test_should_output_header_followed_by_three_expenses_in_date_order(self):
+        # Given
+            # an expense report without any expense
+        expense_report = ExpenseReport()  # an expense report without any expense
+        expense_report.setBeginningBalance(1035.00)
+        expense_report.initialize("09/26/2024", "Groceries", 99.00)
+        expense_report.initialize("10/03/2024", "Car Repair", 450.00)
+        expense_report.initialize("09/25/2024", "Movies", 35.00)
+        # When
+        expense_report_output = expense_report.generate_report()
+
+        # Then
+        (assert_that(expense_report_output, "export report")
+            .starts_with("| Date | Description | Amount | Balance |")
+            .contains("| 09/25/2024 | Movies | 35.00 | 1,000.00 |")
+            .contains("| 09/26/2024 | Groceries | 99.00 | 901.00 |")
+            .ends_with("| 10/03/2024 | Car Repair | 450.00 | 451.00 |"))
+
+        (assert_that(expense_report_output, "export report")
+         .is_equal_to_with_diff("""\
+| Date | Description | Amount | Balance |
+| 09/25/2024 | Movies | 35.00 | 1,000.00 |
+| 09/26/2024 | Groceries | 99.00 | 901.00 |
+| 10/03/2024 | Car Repair | 450.00 | 451.00 |"""))
+
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When generating the report, sort the expense lines by date. 

Fixes #1 